### PR TITLE
Add bundle install Step to Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ git clone https://github.com/alexeymezenin/ruby-on-rails-realworld-example-app
 cd ruby-on-rails-realworld-example-app
 ```
 
+Install gems
+
+```
+bundle install
+```
+
 Execute migrations
 
 ```


### PR DESCRIPTION
## Overview

This PR adds a missing step in the installation instructions for setting up the project. Specifically, it includes the `bundle install` command needed for installing Ruby gems.

This update makes the installation guide more comprehensive and user-friendly, especially for those who are new to Ruby on Rails.

## Details

- Added "Install gems" section in README.md
- Included the `bundle install` command as part of the installation steps


